### PR TITLE
As we use standard encryption set ITSAppUsesNonExemptEncryption to false

### DIFF
--- a/ios/Runner/Info-Debug.plist
+++ b/ios/Runner/Info-Debug.plist
@@ -59,5 +59,7 @@
 	<false/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>

--- a/ios/Runner/Info-Release.plist
+++ b/ios/Runner/Info-Release.plist
@@ -55,5 +55,7 @@
 	<false/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixing the warning in app connect while publishing the app.
[Source](https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption)