### PR TITLE
Auto assign groups after review is completed

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -84,4 +84,4 @@ workflows:
         submit_to_testflight: true
         submit_to_app_store: false
         beta_groups:
-          - pariyatti-beta-testers
+          - Staff and Volunteers


### PR DESCRIPTION
According to the documentation on codemagic, 


> Post-processing of App Store Connect distribution
> Some App Store Connect actions, like submitting the build to TestFlight beta review, distributing the build to beta groups and uploading release notes take place asynchronously in the post-processing step after the app artifact has been successfully published to App Store Connect and the main workflow has completed running in Codemagic. This avoids using the macOS build machine while we are waiting for Apple to complete processing the build and it becomes available for further actions.

[https://docs.codemagic.io/flutter-publishing/publishing-to-app-store/](https://docs.codemagic.io/flutter-publishing/publishing-to-app-store/)

So the builds will be auto assigned the beta tester group after review is completed. Currently, because the group name was not correct, this async process must have been failing. And as it not part of the build process, I didn't see that in logs.