### PR TITLE
Move target api version for android to 34

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,8 +32,8 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "33.0.0"
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -46,7 +46,7 @@ android {
     defaultConfig {
         applicationId "app.pariyatti"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
 The minCompileSdk (34) specified in a
     dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
     is greater than this module's compileSdkVersion (android-33).
     Dependency: androidx.media3:media3-exoplayer-hls:1.3.1.
     AAR metadata file: /Users/builder/.gradle/caches/transforms-3/33171ab198e9bb765979b26190f696fc/transformed/jetified-media3-exoplayer-hls-1.3.1/META-INF/com/android/build/gradle/aar-metadata.properties.