### PR TITLE
Android gradle plugin major version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 
 ```
 % flutter --version
-Flutter 3.16.5 • channel stable • https://github.com/flutter/flutter.git
-Framework • revision 78666c8dc5 (2 weeks ago) • 2023-12-19 16:14:14 -0800
-Engine • revision 3f3e560236
-Tools • Dart 3.2.3 • DevTools 2.28.4
+Flutter 3.22.2 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 761747bfc5 (2 weeks ago) • 2024-06-05 22:15:13 +0200
+Engine • revision edd8546116
+Tools • Dart 3.4.3 • DevTools 2.34.3
 ```
 
 ## Dev Setup: Android

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,10 +22,6 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 if (keystorePropertiesFile.exists()) {
@@ -33,7 +30,16 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     compileSdkVersion 34
-    buildToolsVersion "34.0.0"
+    buildToolsVersion '34.0.0'
+    namespace 'com.example.patta'
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+    compileOptions {
+        sourceCompatibility '17'
+        targetCompatibility '17'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -44,12 +50,12 @@ android {
     }
 
     defaultConfig {
-        applicationId "app.pariyatti"
-        minSdkVersion 21
+        applicationId 'app.pariyatti'
+        minSdkVersion 24
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     signingConfigs {
@@ -73,7 +79,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
        additional functionality it is fine to subclass or reimplement
        FlutterApplication and put your custom class here. -->
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
   <application
     android:name="${applicationName}"
     android:icon="@mipmap/launcher_icon"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.0'
-    repositories {
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,15 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.21" apply false
 }
+
+include ":app"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   cached_network_image: ^3.2.1
-  connectivity_plus: ^5.0.2
+  connectivity_plus: ^6.0.3
   cupertino_icons: ^1.0.4 # iOS-style icons
   dio: ^5.0.3
   dio_cache_interceptor: ^3.2.2
@@ -37,7 +37,7 @@ dependencies:
   shared_preferences: ^2.0.12
   sqlite3_flutter_libs: ^0.5.7 # Workaround to open sqlite3 on old Android versions
   video_player: ^2.2.11
-  share_plus: ^7.0.1
+  share_plus: ^9.0.0
   url_launcher: ^6.1.7
 
 dev_dependencies:


### PR DESCRIPTION
@deobald One change to highlight is version upgrade of minSdkVersion 21 to minSdkVersion 24.

Changes:

- Tested with flutter version 3.22.2
- move from imperative to declarative https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
- build tools version 34.0.0
- version 8 breaking changes include setting namespace https://developer.android.com/build/configure-app-module#set-namespace
- mobile-app/android/app/src/main/AndroidManifest.xml: Error: When targeting Android 13 or higher, posting a permission requires holding the POST_NOTIFICATIONS permission (usage from com.google.android.exoplayer2.offline.DownloadService.ForegroundNotificationUpdater) [NotificationPermission]

     Explanation for issues of type "NotificationPermission":
     When targeting Android 13 and higher, posting permissions requires holding
     the runtime permission android.permission.POST_NOTIFICATIONS.

According to https://apilevels.com/ this would make the updates of the new versions available to only devices that are running greater than Android 7. In terms of percentages as of today, that's a reduction of about 2.5% of devices.


<img width="1491" alt="Screenshot 2024-06-22 at 13 52 35" src="https://github.com/pariyatti/mobile-app/assets/4284516/f8e1d8ef-bbd4-4fe4-9523-2986772d27ad">

i have tested this branch with codemagic using a branch based build. the target version is `1.0.111`